### PR TITLE
Update triton xpu llvm to 5e5a22ca

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,16 @@ jobs:
             dist: centos-7
           - os: macos-13
             dist: ubuntu-18.04
+          - os: macos-13
+            dist: local
           - os: ubuntu-latest
             dist: local
           - os: macos-13-arm64
             dist: centos-7
           - os: macos-13-arm64
             dist: ubuntu-18.04
+          - os: macos-13-arm64
+            dist: local
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,11 @@ name: Build
 on:
   pull_request:
     branches:
-      - main
+      - xpu
   push:
     branches:
-      - main
+      - xpu
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
Rebased LLVM branch: https://github.com/quintinwang5/llvm-project/tree/triton_rebase_5e5a22ca
comes from Triton commit [Bump LLVM version to 5e5a22ca](https://github.com/openai/triton/commit/34f165d6633713a2c9b667927c3baaf018157ef1)